### PR TITLE
Format money values

### DIFF
--- a/src/components/RofrDataTable.vue
+++ b/src/components/RofrDataTable.vue
@@ -9,13 +9,14 @@
     <template #header="props">
       <b-tooltip
         :active="!!props.column.meta"
-        :label="props.column.meta"
+        :label="props.column.meta || ''"
         multilined
         is-large
         dashed
         animated
-        >{{ props.column.label }}</b-tooltip
       >
+        {{ props.column.label }}
+      </b-tooltip>
     </template>
     <template>
       <b-table-column field="status" label="Status" sortable v-slot="props">

--- a/src/components/RofrDataTable.vue
+++ b/src/components/RofrDataTable.vue
@@ -2,7 +2,6 @@
   <b-table
     :selected.sync="selected"
     :data="data"
-    :columns="columns"
     default-sort="status"
     focusable
     @update:selected="$emit('update:selected', selected)"
@@ -18,6 +17,98 @@
         >{{ props.column.label }}</b-tooltip
       >
     </template>
+    <template>
+      <b-table-column field="status" label="Status" sortable v-slot="props">
+        {{ props.row.status }}
+      </b-table-column>
+      <b-table-column field="user" label="User" sortable v-slot="props">
+        {{ props.row.user }}
+      </b-table-column>
+      <b-table-column
+        field="pricePerPoint"
+        label="Price per Point"
+        numeric
+        sortable
+        v-slot="props"
+      >
+        ${{ props.row.pricePerPoint.toLocaleString("en") }}
+      </b-table-column>
+      <b-table-column
+        field="pricePerPointNormalized"
+        label="Price per Point (Normalized)"
+        meta="Normalized Price includes closing cost fees and a unique algorithm around whether the contract is stripped or loaded. For every point remaining from the previous use year the contract price is reduced ($15). For every point used in the current or next use year the contract price is increased ($17/$19)."
+        numeric
+        sortable
+        v-slot="props"
+      >
+        ${{ props.row.pricePerPointNormalized.toLocaleString("en") }}
+      </b-table-column>
+      <b-table-column
+        field="pricePerLifetimePoint"
+        label="Price per Lifetime Point"
+        numeric
+        sortable
+        v-slot="props"
+      >
+        ${{ props.row.pricePerLifetimePoint.toLocaleString("en") }}
+      </b-table-column>
+      <b-table-column
+        field="totlaCost"
+        label="Total Cost"
+        numeric
+        sortable
+        v-slot="props"
+      >
+        ${{ props.row.totalCost.toLocaleString("en") }}
+      </b-table-column>
+      <b-table-column
+        field="points"
+        label="Points"
+        numeric
+        sortable
+        v-slot="props"
+      >
+        {{ props.row.points.toLocaleString("en") }}
+      </b-table-column>
+      <b-table-column field="resort" label="Resort" sortable v-slot="props">
+        {{ props.row.resort }}
+      </b-table-column>
+      <b-table-column
+        field="useYear"
+        label="Use Year (UY)"
+        sortable
+        v-slot="props"
+      >
+        {{ props.row.useYear }}
+      </b-table-column>
+      <b-table-column
+        field="availablePoints"
+        label="Available Points"
+        sortable
+        v-slot="props"
+      >
+        ${{ props.row.availablePoints }}
+      </b-table-column>
+      <b-table-column field="notes" label="Notes" sortable v-slot="props">
+        {{ props.row.Notes }}
+      </b-table-column>
+      <b-table-column
+        field="dateSent"
+        label="Date Sent"
+        sortable
+        v-slot="props"
+      >
+        {{ props.row.dateSent }}
+      </b-table-column>
+      <b-table-column
+        field="dateResolved"
+        label="Date Resolved"
+        sortable
+        v-slot="props"
+      >
+        {{ props.row.dateResolved }}
+      </b-table-column>
+    </template>
   </b-table>
 </template>
 
@@ -25,82 +116,7 @@
 export default {
   props: ["data", "selected"],
   data() {
-    return {
-      columns: [
-        {
-          sortable: true,
-          label: "Status",
-          field: "status",
-        },
-        {
-          sortable: true,
-          label: "User",
-          field: "user",
-        },
-        {
-          sortable: true,
-          numeric: true,
-          label: "Price per Point",
-          field: "pricePerPoint",
-        },
-        {
-          sortable: true,
-          numeric: true,
-          label: "Price per Point (Normalized)",
-          field: "pricePerPointNormalized",
-          meta:
-            "Normalized Price includes closing cost fees and a unique algorithm around whether the contract is stripped or loaded. For every point remaining from the previous use year the contract price is reduced ($15). For every point used in the current or next use year the contract price is increased ($17/$19).",
-        },
-        {
-          sortable: true,
-          numeric: true,
-          label: "Price per Lifetime Point",
-          field: "pricePerLifetimePoint",
-        },
-        {
-          sortable: true,
-          numeric: true,
-          label: "Total Cost",
-          field: "totalCost",
-        },
-        {
-          sortable: true,
-          numeric: true,
-          label: "Points",
-          field: "points",
-        },
-        {
-          sortable: true,
-          label: "Resort",
-          field: "resort",
-        },
-        {
-          sortable: true,
-          label: "Use Year (UY)",
-          field: "useYear",
-        },
-        {
-          sortable: true,
-          label: "Available Points",
-          field: "availablePoints",
-        },
-        {
-          sortable: true,
-          label: "Notes",
-          field: "notes",
-        },
-        {
-          sortable: true,
-          label: "Date Sent",
-          field: "dateSent",
-        },
-        {
-          sortable: true,
-          label: "Date Resolved",
-          field: "dateResolved",
-        },
-      ],
-    };
+    return {};
   },
 };
 </script>

--- a/src/util/aggregate.js
+++ b/src/util/aggregate.js
@@ -23,10 +23,10 @@ export default {
       return this.getAverage(contracts, "points");
     },
     getAveragePricePerPoint: function (contracts) {
-      return "$" + this.getAverage(contracts, "pricePerPoint");
+      return this.asCurrencyFormat(this.getAverage(contracts, "pricePerPoint"));
     },
     getAverageTotalCost: function (contracts) {
-      return "$" + this.getAverage(contracts, "totalCost");
+      return this.asCurrencyFormat(this.getAverage(contracts, "totalCost"));
     },
     getAverage: function (contracts, prop) {
       // console.log(contracts);
@@ -39,6 +39,9 @@ export default {
       }, 0);
       var avg = sum / contracts.length;
       return avg.toFixed(2);
+    },
+    asCurrencyFormat: function (num) {
+      return "$" + parseFloat(num).toLocaleString("en");
     },
   },
 };

--- a/src/views/CompareContracts.vue
+++ b/src/views/CompareContracts.vue
@@ -9,6 +9,7 @@
         label="Selected Contract"
         v-slot="props"
         :visible="data.length > 0"
+        numeric
       >
         {{ props.row.selected }}
       </b-table-column>
@@ -17,6 +18,7 @@
         label="All Contracts"
         v-slot="props"
         :visible="data.length > 0"
+        numeric
       >
         {{ props.row.all }}
       </b-table-column>
@@ -25,11 +27,17 @@
         label="Same Resort"
         v-slot="props"
         :visible="data.length > 0"
+        numeric
       >
         {{ props.row.resort }}
       </b-table-column>
 
-      <b-table-column label="Same UY" v-slot="props" :visible="data.length > 0">
+      <b-table-column
+        label="Same UY"
+        v-slot="props"
+        :visible="data.length > 0"
+        numeric
+      >
         {{ props.row.uy }}
       </b-table-column>
 


### PR DESCRIPTION
Fixes #1096

Formats money values with a `$` and comma separators.

Data table:
![image](https://user-images.githubusercontent.com/75132/95132311-92a2d600-072d-11eb-814c-b10bced7d95b.png)

Compare:
![image](https://user-images.githubusercontent.com/75132/95132706-33919100-072e-11eb-8213-41a4f677f79e.png)
