### PR TITLE
Upgrade dependencies to latest compatible versions

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,9 +6,9 @@
     "": {
       "name": "functions",
       "dependencies": {
-        "cheerio": "^1.1.0",
-        "firebase-admin": "^13.7.0",
-        "firebase-functions": "^7.2.3",
+        "cheerio": "^1.2.0",
+        "firebase-admin": "^13.8.0",
+        "firebase-functions": "^7.2.5",
         "moment": "^2.30.1"
       },
       "devDependencies": {
@@ -3249,9 +3249,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4385,9 +4385,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4892,9 +4892,9 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.7.0.tgz",
-      "integrity": "sha512-o3qS8zCJbApe7aKzkO2Pa380t9cHISqeSd3blqYTtOuUUUua3qZTLwNWgGUOss3td6wbzrZhiHIj3c8+fC046Q==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.8.0.tgz",
+      "integrity": "sha512-iawoQkmZbsA+2DY5UEuB8f6jSlskzzySoye0D2F6e3zlDZX9DUcXf0HhZqLUn/P6WhLGvTf6ZtCmshZvhAgTYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
@@ -4905,7 +4905,7 @@
         "google-auth-library": "^10.6.1",
         "jsonwebtoken": "^9.0.0",
         "jwks-rsa": "^3.1.0",
-        "node-forge": "^1.3.1",
+        "node-forge": "^1.4.0",
         "uuid": "^11.0.2"
       },
       "engines": {
@@ -4917,9 +4917,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.3.tgz",
-      "integrity": "sha512-myrnxuvmfAQYsaat2Crv1k2qpb2BuRUVRfr1V/nVLNO4sObgd06NT08TsVF3PA6EkxyUsOKXmcvmGFiJC0R2fQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
+      "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
@@ -5296,9 +5296,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -6821,9 +6821,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,9 +13,9 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
-    "cheerio": "^1.1.0",
-    "firebase-admin": "^13.7.0",
-    "firebase-functions": "^7.2.3",
+    "cheerio": "^1.2.0",
+    "firebase-admin": "^13.8.0",
+    "firebase-functions": "^7.2.5",
     "moment": "^2.30.1"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.2.0",
-        "@oruga-ui/oruga-next": "^0.13.2",
+        "@oruga-ui/oruga-next": "^0.13.3",
         "@oruga-ui/theme-bulma": "^0.9.0",
         "@vueform/multiselect": "^2.6.11",
         "bulma": "^1.0.4",
         "echarts": "^6.0.0",
-        "firebase": "^12.11.0",
+        "firebase": "^12.12.0",
         "moment": "^2.30.1",
         "moving-average": "^1.0.1",
         "register-service-worker": "^1.7.2",
@@ -23,7 +23,7 @@
         "vue-gtag": "^3.7.0",
         "vue-json-csv": "^2.1.0",
         "vue-router": "^5.0.4",
-        "vuefire": "^3.1.24"
+        "vuefire": "^3.2.2"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.5",
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.10.0.tgz",
-      "integrity": "sha512-1lI6HomyoO/8RSJb6ItyHLpHnB2z27m5F4aX/Vpi1nhwWoxdNjkq+6UQOykHyCE0KairojOE5qQ20i1tnF0nNA==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.0.tgz",
+      "integrity": "sha512-+oqOne/h5J51LezazR+VyzKe3AK455W29JXnb4jOeVvQhC7FymledN5+XE+w5vEcMhRQ6n1f62fdGs4A44X32A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.3",
@@ -541,9 +541,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.10.tgz",
-      "integrity": "sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==",
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
+      "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
@@ -607,12 +607,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.10.tgz",
-      "integrity": "sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
+      "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.14.10",
+        "@firebase/app": "0.14.11",
         "@firebase/component": "0.7.2",
         "@firebase/logger": "0.5.0",
         "@firebase/util": "1.15.0",
@@ -623,15 +623,18 @@
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
     },
     "node_modules/@firebase/auth": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.12.2.tgz",
-      "integrity": "sha512-CZJL8V10Vzibs+pDTXdQF+hot1IigIoqF4a4lA/qr5Deo1srcefiyIfgg28B67Lk7IxZhwfJMuI+1bu2xBmV0A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
@@ -644,7 +647,7 @@
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^2.2.0"
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -653,12 +656,12 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.4.tgz",
-      "integrity": "sha512-2pj8m/hnqXvMLfC0Mk+fORVTM5DQPkS6l8JpMgtoAWGVgCmYnoWdFMaNWtKbmCxBEyvMA3FlnCJyzrUSMWTfuA==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.5.tgz",
+      "integrity": "sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.12.2",
+        "@firebase/auth": "1.13.0",
         "@firebase/auth-types": "0.13.0",
         "@firebase/component": "0.7.2",
         "@firebase/util": "1.15.0",
@@ -701,9 +704,9 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.5.0.tgz",
-      "integrity": "sha512-G3GYHpWNJJ95502RQLApzw0jaG3pScHl+J/2MdxIuB51xtHnkRL6KvIAP3fFF1drUewWJHOnDA1U+q4Evf3KSw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.6.0.tgz",
+      "integrity": "sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.4",
@@ -735,14 +738,14 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.2.tgz",
-      "integrity": "sha512-j4A6IhVZbgxAzT6gJJC2PfOxYCK9SrDrUO7nTM4EscTYtKkAkzsbKoCnDdjFapQfnsncvPWjqVTr/0PffUwg3g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
         "@firebase/database": "1.1.2",
-        "@firebase/database-types": "1.0.18",
+        "@firebase/database-types": "1.0.19",
         "@firebase/logger": "0.5.0",
         "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
@@ -752,19 +755,19 @@
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.18.tgz",
-      "integrity": "sha512-yOY8IC2go9lfbVDMiy2ATun4EB2AFwocPaQADwMN/RHRUAZSM4rlAV7PGbWPSG/YhkJ2A9xQAiAENgSua9G5Fg==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
+        "@firebase/app-types": "0.9.4",
         "@firebase/util": "1.15.0"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.13.0.tgz",
-      "integrity": "sha512-7i4cVNJXTMim7/P7UsNim0DwyLPk4QQ3y1oSNzv4l0ykJOKYCiFMOuEeUxUYvrReXDJxWHrT/4XMeVQm+13rRw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.0.tgz",
+      "integrity": "sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
@@ -783,13 +786,13 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.7.tgz",
-      "integrity": "sha512-Et4XxtGnjp0Q9tmaEMETnY5GHJ8gQ9+RN6sSTT4ETWKmym2d6gIjarw0rCQcx+7BrWVYLEIOAXSXysl0b3xnUA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz",
+      "integrity": "sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/component": "0.7.2",
-        "@firebase/firestore": "4.13.0",
+        "@firebase/firestore": "4.14.0",
         "@firebase/firestore-types": "3.0.3",
         "@firebase/util": "1.15.0",
         "tslib": "^2.1.0"
@@ -1272,12 +1275,12 @@
       "license": "MIT"
     },
     "node_modules/@oruga-ui/oruga-next": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@oruga-ui/oruga-next/-/oruga-next-0.13.2.tgz",
-      "integrity": "sha512-7ePgcjxm6G31wyek75aiV8z+QZrfzFHwDpRFF+nkVEtm1Fv2RIed0eP11EQAklpuNjkmZp1gWEjbZAQr3yaMYQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@oruga-ui/oruga-next/-/oruga-next-0.13.3.tgz",
+      "integrity": "sha512-RjX2+IanamfIUTjrUwddeEVWMwkHCe6daaDHOcBrsCTT8UwyF3BWZJMH5SLIocKPapsC7lHdqCLTcXREXtdOPw==",
       "license": "MIT",
       "dependencies": {
-        "vue-component-type-helpers": "^3.2.5"
+        "vue-component-type-helpers": "^3.2.6"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
@@ -3121,9 +3124,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3567,26 +3570,26 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.11.0.tgz",
-      "integrity": "sha512-W9f3Y+cgQYgF9gvCGxt0upec8zwAtiQVcHuU8MfzUIgVU/9fRQWtu48Geiv1lsigtBz9QHML++Km9xAKO5GB5Q==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.0.tgz",
+      "integrity": "sha512-5Ap+pN5iEJUvBlQEZEmLuUm7Gvu6I5xv1jZ5SiSNyw4jrwlHo+4tmZv3OPPoKfN9eo1kBwyyBvi+pWHIPXwfYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.10.0",
+        "@firebase/ai": "2.11.0",
         "@firebase/analytics": "0.10.21",
         "@firebase/analytics-compat": "0.2.27",
-        "@firebase/app": "0.14.10",
+        "@firebase/app": "0.14.11",
         "@firebase/app-check": "0.11.2",
         "@firebase/app-check-compat": "0.4.2",
-        "@firebase/app-compat": "0.5.10",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.12.2",
-        "@firebase/auth-compat": "0.6.4",
-        "@firebase/data-connect": "0.5.0",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
         "@firebase/database": "1.1.2",
-        "@firebase/database-compat": "2.1.2",
-        "@firebase/firestore": "4.13.0",
-        "@firebase/firestore-compat": "0.4.7",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
         "@firebase/functions": "0.13.3",
         "@firebase/functions-compat": "0.4.3",
         "@firebase/installations": "0.6.21",
@@ -3721,9 +3724,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4415,9 +4418,9 @@
     },
     "node_modules/lodash.pick": {
       "name": "lodash",
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.pickby": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
-    "@oruga-ui/oruga-next": "^0.13.2",
+    "@oruga-ui/oruga-next": "^0.13.3",
     "@oruga-ui/theme-bulma": "^0.9.0",
     "@vueform/multiselect": "^2.6.11",
     "bulma": "^1.0.4",
     "echarts": "^6.0.0",
-    "firebase": "^12.11.0",
+    "firebase": "^12.12.0",
     "moment": "^2.30.1",
     "moving-average": "^1.0.1",
     "register-service-worker": "^1.7.2",
@@ -28,7 +28,7 @@
     "vue-gtag": "^3.7.0",
     "vue-json-csv": "^2.1.0",
     "vue-router": "^5.0.4",
-    "vuefire": "^3.1.24"
+    "vuefire": "^3.2.2"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.5",


### PR DESCRIPTION
## Summary
This PR updates multiple dependencies across both the main application and Firebase functions to their latest compatible versions.

## Key Changes
- **Functions dependencies:**
  - cheerio: ^1.1.0 → ^1.2.0
  - firebase-admin: ^13.7.0 → ^13.8.0
  - firebase-functions: ^7.2.3 → ^7.2.5

- **Main application dependencies:**
  - @oruga-ui/oruga-next: ^0.13.2 → ^0.13.3
  - firebase: ^12.11.0 → ^12.12.0
  - vuefire: ^3.1.24 → ^3.2.2

## Details
All updates are within compatible semver ranges (patch and minor version bumps), ensuring backward compatibility while bringing in bug fixes and minor feature improvements. The lockfiles have been updated to reflect the transitive dependency resolutions.

https://claude.ai/code/session_015RK8mKb2C9sbr58z822XLn